### PR TITLE
Add calculated stop times

### DIFF
--- a/apps/bus_detective/lib/bus_detective/gtfs/departure.ex
+++ b/apps/bus_detective/lib/bus_detective/gtfs/departure.ex
@@ -1,0 +1,4 @@
+defmodule BusDetective.GTFS.Departure do
+  @moduledoc false
+  defstruct [:realtime?, :time, :delay, :scheduled_time, :route, :trip]
+end

--- a/apps/bus_detective/lib/bus_detective/gtfs/gtfs.ex
+++ b/apps/bus_detective/lib/bus_detective/gtfs/gtfs.ex
@@ -31,7 +31,7 @@ defmodule BusDetective.GTFS do
         on: trip.service_id == effective_service.service_id,
         where:
           fragment(
-            "(start_time(?) + (? * INTERVAL '1 second')) BETWEEN (? AT TIME ZONE ?) AND (? AT TIME ZONE ?)",
+            "(start_time(?) + ?) BETWEEN (? AT TIME ZONE ?) AND (? AT TIME ZONE ?)",
             effective_service.date,
             st.departure_time,
             ^utc_start_time,
@@ -41,21 +41,21 @@ defmodule BusDetective.GTFS do
           ),
         order_by:
           fragment(
-            "start_time(?) + (? * INTERVAL '1 second')",
+            "start_time(?) + ?",
             effective_service.date,
             st.departure_time
           ),
         select_merge: %{
           calculated_arrival_time:
             fragment(
-              "((start_time(?) + (? * INTERVAL '1 second')) AT TIME ZONE ?) AS calculated_arrival_time",
+              "((start_time(?) + ?) AT TIME ZONE ?) AS calculated_arrival_time",
               effective_service.date,
               st.arrival_time,
               agency.timezone
             ),
           calculated_departure_time:
             fragment(
-              "((start_time(?) + (? * INTERVAL '1 second')) AT TIME ZONE ?) AS calculated_departure_time",
+              "((start_time(?) + ?) AT TIME ZONE ?) AS calculated_departure_time",
               effective_service.date,
               st.departure_time,
               agency.timezone

--- a/apps/bus_detective/lib/bus_detective/gtfs/interval.ex
+++ b/apps/bus_detective/lib/bus_detective/gtfs/interval.ex
@@ -1,0 +1,42 @@
+defmodule BusDetective.GTFS.Interval do
+  @moduledoc """
+  This implements Interval support for Postgrex that used to be in Ecto but no longer is.
+  """
+
+  defstruct [:hours, :minutes, :seconds]
+
+  @behaviour Ecto.Type
+  def type, do: Postgrex.Interval
+
+  def cast(value) when is_binary(value) do
+    [hours, minutes, seconds] =
+      value
+      |> String.split(":")
+      |> Enum.map(&String.to_integer/1)
+
+    {:ok, %__MODULE__{hours: hours, minutes: minutes, seconds: seconds}}
+  end
+
+  def cast(%__MODULE__{} = interval) do
+    {:ok, interval}
+  end
+
+  def dump(%__MODULE__{hours: hours, minutes: minutes, seconds: seconds}) do
+    total_seconds = (hours || 0) * 3600 + (minutes || 0) * 60 + seconds
+    {:ok, %Postgrex.Interval{secs: total_seconds}}
+  end
+
+  def load(%Postgrex.Interval{days: days, secs: seconds}) do
+    total_seconds = days * 86400 + seconds
+    hours = trunc(total_seconds / 3600)
+    minutes = trunc(rem(total_seconds, 3600) / 60)
+    seconds = rem(rem(total_seconds, 3600), 60)
+    {:ok, %__MODULE__{hours: hours, minutes: minutes, seconds: seconds}}
+  end
+end
+
+defimpl Inspect, for: [BusDetective.GTFS.Interval] do
+  def inspect(inv, _opts) do
+    inspect(Map.from_struct(inv))
+  end
+end

--- a/apps/bus_detective/lib/bus_detective/gtfs/route_stop.ex
+++ b/apps/bus_detective/lib/bus_detective/gtfs/route_stop.ex
@@ -1,4 +1,5 @@
 defmodule BusDetective.GTFS.RouteStop do
+  @moduledoc false
   use Ecto.Schema
   import Ecto.Changeset
 

--- a/apps/bus_detective/lib/bus_detective/gtfs/stop_time.ex
+++ b/apps/bus_detective/lib/bus_detective/gtfs/stop_time.ex
@@ -4,7 +4,7 @@ defmodule BusDetective.GTFS.StopTime do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias BusDetective.GTFS.{Agency, Stop, Trip}
+  alias BusDetective.GTFS.{Agency, Interval, Stop, Trip}
 
   schema "stop_times" do
     belongs_to(:agency, Agency)
@@ -14,10 +14,10 @@ defmodule BusDetective.GTFS.StopTime do
     # we want hours, minutes, seconds
     # keeping it in Interval format for the short term to maintain consistency with
     # Rails BD.
-    field(:arrival_time, :integer)
+    field(:arrival_time, Interval)
     field(:calculated_arrival_time, :utc_datetime, virtual: true)
     field(:calculated_departure_time, :utc_datetime, virtual: true)
-    field(:departure_time, :integer)
+    field(:departure_time, Interval)
     field(:drop_off_type, :integer)
     field(:pickup_type, :integer)
     field(:shape_dist_traveled, :float)

--- a/apps/bus_detective/lib/bus_detective/gtfs/stop_time.ex
+++ b/apps/bus_detective/lib/bus_detective/gtfs/stop_time.ex
@@ -15,6 +15,8 @@ defmodule BusDetective.GTFS.StopTime do
     # keeping it in Interval format for the short term to maintain consistency with
     # Rails BD.
     field(:arrival_time, :integer)
+    field(:calculated_arrival_time, :utc_datetime, virtual: true)
+    field(:calculated_departure_time, :utc_datetime, virtual: true)
     field(:departure_time, :integer)
     field(:drop_off_type, :integer)
     field(:pickup_type, :integer)

--- a/apps/bus_detective/priv/repo/migrations/20180704041514_create_stop_times.exs
+++ b/apps/bus_detective/priv/repo/migrations/20180704041514_create_stop_times.exs
@@ -10,8 +10,8 @@ defmodule BusDetective.Repo.Migrations.CreateStopTimes do
       add(:pickup_type, :integer)
       add(:drop_off_type, :integer)
       add(:shape_dist_traveled, :float)
-      add(:arrival_time, :integer)
-      add(:departure_time, :integer)
+      add(:arrival_time, :interval)
+      add(:departure_time, :interval)
       add(:stop_sequence, :integer)
 
       timestamps()

--- a/apps/bus_detective/priv/repo/migrations/20180708200151_add_calculated_stop_functions.exs
+++ b/apps/bus_detective/priv/repo/migrations/20180708200151_add_calculated_stop_functions.exs
@@ -1,0 +1,57 @@
+defmodule BusDetective.Repo.Migrations.AddCalculatedStopFunctions do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    CREATE VIEW service_days AS
+    SELECT sd.id,
+    sd.agency_id,
+    sd.remote_id,
+    sd.start_date,
+    sd.end_date,
+    sd.dow
+    FROM ( SELECT services.id,
+    services.agency_id,
+    services.remote_id,
+    services.start_date,
+    services.end_date,
+    unnest(ARRAY['monday'::text, 'tuesday'::text, 'wednesday'::text, 'thursday'::text, 'friday'::text, 'saturday'::text, 'sunday'::text]) AS dow,
+    unnest(ARRAY[services.monday, services.tuesday, services.wednesday, services.thursday, services.friday, services.saturday, services.sunday]) AS active
+    FROM services) sd
+    WHERE sd.active;
+    """)
+
+    execute("""
+        CREATE FUNCTION effective_services(start_date date DEFAULT ('now'::text)::date, end_date date DEFAULT (('now'::text)::date + '1 day'::interval)) RETURNS TABLE(agency_id bigint, service_id bigint, date date, dow character)
+        LANGUAGE sql
+        AS $$
+      SELECT agencies.id as agency_id, service_exceptions.service_id, d as date, rtrim(to_char(days.d, 'day')) as dow
+         FROM agencies
+           CROSS JOIN (SELECT d::date FROM generate_series(start_date, end_date, interval '1 day') d) days
+           INNER JOIN service_days ON service_days.dow = rtrim(to_char(days.d, 'day')) AND agencies.id = service_days.agency_id and days.d between service_days.start_date and service_days.end_date
+           INNER JOIN service_exceptions ON service_exceptions.date = days.d AND agencies.id = service_exceptions.agency_id
+           WHERE service_exceptions.exception = 1
+         UNION ALL
+         SELECT agencies.id as agency_id, service_days.id, d as date, rtrim(to_char(days.d, 'day')) as dow
+         FROM agencies
+           CROSS JOIN (SELECT d::date FROM generate_series(start_date, end_date, interval '1 day') d) days
+           INNER JOIN service_days ON service_days.dow = rtrim(to_char(days.d, 'day')) AND agencies.id = service_days.agency_id and days.d between service_days.start_date and service_days.end_date
+           LEFT JOIN service_exceptions ON service_exceptions.date = days.d AND agencies.id = service_exceptions.agency_id AND service_days.id = service_exceptions.service_id
+           WHERE service_exceptions IS NULL OR service_exceptions.exception != 2
+    $$;
+    """)
+
+    execute("""
+    CREATE FUNCTION start_time(start_date date DEFAULT ('now'::text)::date) RETURNS timestamp without time zone
+    LANGUAGE plpgsql
+    AS $$
+    DECLARE
+    noon varchar(50);
+    BEGIN
+    SELECT INTO noon to_char(start_date, 'YYYY-mm-dd') || ' 12:00:00';
+    RETURN noon::timestamp - interval '12 hours';
+    END;
+    $$;
+    """)
+  end
+end

--- a/apps/bus_detective/test/bus_detective/gtfs/calculated_stop_time_test.exs
+++ b/apps/bus_detective/test/bus_detective/gtfs/calculated_stop_time_test.exs
@@ -31,20 +31,20 @@ defmodule BusDetective.CalculatedStopTimeTest do
       :ok
     end
 
-    test "when requesting stops on the same day it finds those stops" do
+    test "when requesting stops on the same day it finds those stops", %{stop: stop} do
       start_time = Timex.parse!("2015-05-12 22:00:00-0400", "{ISO:Extended}")
       end_time = Timex.parse!("2015-05-12 23:30:00-0400", "{ISO:Extended}")
 
-      stop_times = GTFS.calculated_stop_times_between(start_time, end_time)
+      stop_times = GTFS.calculated_stop_times_between(stop, start_time, end_time)
       assert 2 == length(stop_times)
       assert Timezone.convert(start_time, :utc) == Timex.to_datetime(List.first(stop_times).calculated_departure_time)
     end
 
-    test "with stops that cross the local time day boundary it finds those stops" do
+    test "with stops that cross the local time day boundary it finds those stops", %{stop: stop} do
       start_time = Timex.parse!("2015-05-12 23:00:00-0400", "{ISO:Extended}")
       end_time = Timex.parse!("2015-05-13 01:30:00-0400", "{ISO:Extended}")
 
-      stop_times = GTFS.calculated_stop_times_between(start_time, end_time)
+      stop_times = GTFS.calculated_stop_times_between(stop, start_time, end_time)
       assert 3 == length(stop_times)
     end
   end
@@ -59,19 +59,19 @@ defmodule BusDetective.CalculatedStopTimeTest do
       :ok
     end
 
-    test "having stops on the same day it finds those stops" do
+    test "having stops on the same day it finds those stops", %{stop: stop} do
       start_time = Timex.parse!("2015-05-12 22:00:00-0400", "{ISO:Extended}")
       end_time = Timex.parse!("2015-05-12 23:30:00-0400", "{ISO:Extended}")
 
-      stop_times = GTFS.calculated_stop_times_between(start_time, end_time)
+      stop_times = GTFS.calculated_stop_times_between(stop, start_time, end_time)
       assert 2 == length(stop_times)
     end
 
-    test "with stops that cross the local time day boundary it finds those stops" do
+    test "with stops that cross the local time day boundary it finds those stops", %{stop: stop} do
       start_time = Timex.parse!("2015-05-12 23:00:00-0400", "{ISO:Extended}")
       end_time = Timex.parse!("2015-05-13 01:30:00-0400", "{ISO:Extended}")
 
-      stop_times = GTFS.calculated_stop_times_between(start_time, end_time)
+      stop_times = GTFS.calculated_stop_times_between(stop, start_time, end_time)
       assert 3 == length(stop_times)
     end
   end

--- a/apps/bus_detective/test/bus_detective/gtfs/calculated_stop_time_test.exs
+++ b/apps/bus_detective/test/bus_detective/gtfs/calculated_stop_time_test.exs
@@ -1,0 +1,78 @@
+defmodule BusDetective.CalculatedStopTimeTest do
+  use BusDetective.DataCase
+
+  alias BusDetective.GTFS
+  # alias BusDetective.GTFS.StopTime
+  alias Timex.Timezone
+
+  setup do
+    agency = insert(:agency)
+
+    trip =
+      insert(
+        :trip,
+        agency: agency,
+        remote_id: "940135",
+        service: insert(:service, agency: agency, tuesday: true, wednesday: true)
+      )
+
+    stop = insert(:stop, agency: agency, remote_id: "HAMBELi")
+
+    {:ok, agency: agency, stop: stop, trip: trip}
+  end
+
+  describe "with stops on different days" do
+    setup %{agency: agency, stop: stop, trip: trip} do
+      insert(:stop_time, agency: agency, stop: stop, trip: trip, departure_time: 79200)
+      insert(:stop_time, agency: agency, stop: stop, trip: trip, departure_time: 82800)
+      insert(:stop_time, agency: agency, stop: stop, trip: trip, departure_time: 1800)
+      insert(:stop_time, agency: agency, stop: stop, trip: trip, departure_time: 3600)
+
+      :ok
+    end
+
+    test "when requesting stops on the same day it finds those stops" do
+      start_time = Timex.parse!("2015-05-12 22:00:00-0400", "{ISO:Extended}")
+      end_time = Timex.parse!("2015-05-12 23:30:00-0400", "{ISO:Extended}")
+
+      stop_times = GTFS.calculated_stop_times_between(start_time, end_time)
+      assert 2 == length(stop_times)
+      assert Timezone.convert(start_time, :utc) == Timex.to_datetime(List.first(stop_times).calculated_departure_time)
+    end
+
+    test "with stops that cross the local time day boundary it finds those stops" do
+      start_time = Timex.parse!("2015-05-12 23:00:00-0400", "{ISO:Extended}")
+      end_time = Timex.parse!("2015-05-13 01:30:00-0400", "{ISO:Extended}")
+
+      stop_times = GTFS.calculated_stop_times_between(start_time, end_time)
+      assert 3 == length(stop_times)
+    end
+  end
+
+  describe "with stops on the same day" do
+    setup %{agency: agency, stop: stop, trip: trip} do
+      insert(:stop_time, agency: agency, stop: stop, trip: trip, departure_time: 22 * 60 * 60)
+      insert(:stop_time, agency: agency, stop: stop, trip: trip, departure_time: 23 * 60 * 60)
+      insert(:stop_time, agency: agency, stop: stop, trip: trip, departure_time: 24 * 60 * 60 + 30 * 60)
+      insert(:stop_time, agency: agency, stop: stop, trip: trip, departure_time: 25 * 60 * 60)
+
+      :ok
+    end
+
+    test "having stops on the same day it finds those stops" do
+      start_time = Timex.parse!("2015-05-12 22:00:00-0400", "{ISO:Extended}")
+      end_time = Timex.parse!("2015-05-12 23:30:00-0400", "{ISO:Extended}")
+
+      stop_times = GTFS.calculated_stop_times_between(start_time, end_time)
+      assert 2 == length(stop_times)
+    end
+
+    test "with stops that cross the local time day boundary it finds those stops" do
+      start_time = Timex.parse!("2015-05-12 23:00:00-0400", "{ISO:Extended}")
+      end_time = Timex.parse!("2015-05-13 01:30:00-0400", "{ISO:Extended}")
+
+      stop_times = GTFS.calculated_stop_times_between(start_time, end_time)
+      assert 3 == length(stop_times)
+    end
+  end
+end

--- a/apps/bus_detective/test/bus_detective/gtfs/calculated_stop_time_test.exs
+++ b/apps/bus_detective/test/bus_detective/gtfs/calculated_stop_time_test.exs
@@ -23,10 +23,10 @@ defmodule BusDetective.CalculatedStopTimeTest do
 
   describe "with stops on different days" do
     setup %{agency: agency, stop: stop, trip: trip} do
-      insert(:stop_time, agency: agency, stop: stop, trip: trip, departure_time: 79200)
-      insert(:stop_time, agency: agency, stop: stop, trip: trip, departure_time: 82800)
-      insert(:stop_time, agency: agency, stop: stop, trip: trip, departure_time: 1800)
-      insert(:stop_time, agency: agency, stop: stop, trip: trip, departure_time: 3600)
+      insert(:stop_time, agency: agency, stop: stop, trip: trip, departure_time: "22:00:00")
+      insert(:stop_time, agency: agency, stop: stop, trip: trip, departure_time: "23:00:00")
+      insert(:stop_time, agency: agency, stop: stop, trip: trip, departure_time: "00:30:00")
+      insert(:stop_time, agency: agency, stop: stop, trip: trip, departure_time: "01:00:00")
 
       :ok
     end
@@ -51,10 +51,10 @@ defmodule BusDetective.CalculatedStopTimeTest do
 
   describe "with stops on the same day" do
     setup %{agency: agency, stop: stop, trip: trip} do
-      insert(:stop_time, agency: agency, stop: stop, trip: trip, departure_time: 22 * 60 * 60)
-      insert(:stop_time, agency: agency, stop: stop, trip: trip, departure_time: 23 * 60 * 60)
-      insert(:stop_time, agency: agency, stop: stop, trip: trip, departure_time: 24 * 60 * 60 + 30 * 60)
-      insert(:stop_time, agency: agency, stop: stop, trip: trip, departure_time: 25 * 60 * 60)
+      insert(:stop_time, agency: agency, stop: stop, trip: trip, departure_time: "22:00:00")
+      insert(:stop_time, agency: agency, stop: stop, trip: trip, departure_time: "23:00:00")
+      insert(:stop_time, agency: agency, stop: stop, trip: trip, departure_time: "24:30:00")
+      insert(:stop_time, agency: agency, stop: stop, trip: trip, departure_time: "25:00:00")
 
       :ok
     end

--- a/apps/bus_detective/test/support/factory.ex
+++ b/apps/bus_detective/test/support/factory.ex
@@ -12,8 +12,6 @@ defmodule BusDetective.Factory do
   end
 
   def service_factory do
-    date = Timex.to_date(Timex.now())
-
     %Service{
       agency: build(:agency),
       remote_id: sequence(:service_remote_id, &"Service-#{&1}"),
@@ -24,8 +22,8 @@ defmodule BusDetective.Factory do
       friday: Enum.random([true, false]),
       saturday: Enum.random([true, false]),
       sunday: Enum.random([true, false]),
-      start_date: Timex.shift(date, days: -30),
-      end_date: Timex.shift(date, days: 30)
+      start_date: Timex.parse!("2000-01-01 00:00:00-0000", "{ISO:Extended}"),
+      end_date: Timex.parse!("3000-01-01 00:00:00-0000", "{ISO:Extended}")
     }
   end
 

--- a/apps/bus_detective/test/support/factory.ex
+++ b/apps/bus_detective/test/support/factory.ex
@@ -1,7 +1,7 @@
 defmodule BusDetective.Factory do
   use ExMachina.Ecto, repo: BusDetective.Repo
 
-  alias BusDetective.GTFS.{Agency, Route, Service, ServiceException, Shape, Stop, StopTime, Trip}
+  alias BusDetective.GTFS.{Agency, Interval, Route, Service, ServiceException, Shape, Stop, StopTime, Trip}
 
   def agency_factory do
     %Agency{
@@ -83,8 +83,8 @@ defmodule BusDetective.Factory do
       trip: build(:trip, agency: agency),
       stop_sequence: stop_time_sequence,
       shape_dist_traveled: stop_time_sequence * 0.5,
-      arrival_time: 56_000 + stop_time_sequence * 2,
-      departure_time: 56_000 + stop_time_sequence * 2 + 1
+      arrival_time: %Interval{seconds: 56_000 + stop_time_sequence * 2},
+      departure_time: %Interval{seconds: 56_000 + stop_time_sequence * 2 + 1}
     }
   end
 

--- a/apps/bus_detective_web/lib/bus_detective_web/controllers/departure_controller.ex
+++ b/apps/bus_detective_web/lib/bus_detective_web/controllers/departure_controller.ex
@@ -1,0 +1,38 @@
+defmodule BusDetectiveWeb.DepartureController do
+  use BusDetectiveWeb, :controller
+
+  alias BusDetective.GTFS
+  alias BusDetective.GTFS.Departure
+  alias Timex.Timezone
+
+  action_fallback(BusDetectiveWeb.FallbackController)
+
+  def index(conn, %{"stop_id" => stop_id_str, "duration" => duration_str}) do
+    with {stop_id, ""} <- Integer.parse(stop_id_str),
+         {duration, ""} <- Integer.parse(duration_str),
+         stop <- GTFS.get_stop!(stop_id),
+         start_time <- Timex.shift(agency_time(stop.agency), minutes: -10),
+         end_time <- Timex.shift(agency_time(stop.agency), hours: duration) do
+      departures =
+        stop
+        |> GTFS.calculated_stop_times_between(start_time, end_time)
+        |> Enum.map(fn stop_time ->
+          %Departure{
+            scheduled_time: stop_time.calculated_departure_time,
+            time: stop_time.calculated_departure_time,
+            realtime?: false,
+            delay: 0,
+            trip: stop_time.trip,
+            route: stop_time.trip.route
+          }
+        end)
+
+      render(conn, "index.json", departures: departures)
+    end
+  end
+
+  defp agency_time(agency) do
+    timezone = Timezone.get(agency.timezone)
+    Timezone.convert(Timex.now(), timezone)
+  end
+end

--- a/apps/bus_detective_web/lib/bus_detective_web/controllers/stop_controller.ex
+++ b/apps/bus_detective_web/lib/bus_detective_web/controllers/stop_controller.ex
@@ -17,10 +17,10 @@ defmodule BusDetectiveWeb.StopController do
     |> render(ErrorView, "400.json")
   end
 
-  # def show(conn, %{"id" => id}) do
-  #   stop = GTFS.get_stop!(id)
-  #   render(conn, "show.json", stop: stop)
-  # end
+  def show(conn, %{"id" => id}) do
+    stop = GTFS.get_stop!(id)
+    render(conn, "show.json", stop: stop)
+  end
 
   defp paging_params(params) do
     [

--- a/apps/bus_detective_web/lib/bus_detective_web/controllers/stop_controller.ex
+++ b/apps/bus_detective_web/lib/bus_detective_web/controllers/stop_controller.ex
@@ -6,7 +6,7 @@ defmodule BusDetectiveWeb.StopController do
 
   action_fallback(BusDetectiveWeb.FallbackController)
 
-  def index(conn, params = %{"query" => query}) do
+  def index(conn, %{"query" => query} = params) do
     results = GTFS.search_stops(Keyword.merge(paging_params(params), query: query))
     render(conn, "index.json", results: results)
   end
@@ -23,7 +23,7 @@ defmodule BusDetectiveWeb.StopController do
   # end
 
   defp paging_params(params) do
-    paging_params = [
+    [
       page: params["page"],
       page_size: params["per_page"]
     ]

--- a/apps/bus_detective_web/lib/bus_detective_web/router.ex
+++ b/apps/bus_detective_web/lib/bus_detective_web/router.ex
@@ -22,6 +22,7 @@ defmodule BusDetectiveWeb.Router do
   scope "/api", BusDetectiveWeb do
     pipe_through(:api)
 
+    resources("/departures", DepartureController, only: [:index])
     resources("/stops", StopController, only: [:index, :show])
   end
 end

--- a/apps/bus_detective_web/lib/bus_detective_web/views/departure_view.ex
+++ b/apps/bus_detective_web/lib/bus_detective_web/views/departure_view.ex
@@ -1,0 +1,30 @@
+defmodule BusDetectiveWeb.DepartureView do
+  use BusDetectiveWeb, :view
+
+  alias BusDetectiveWeb.{DepartureView, RouteView, TripView}
+
+  def render("index.json", %{departures: departures}) do
+    %{data: %{departures: render_many(departures, DepartureView, "departure.json")}}
+  end
+
+  def render("departure.json", %{departure: departure}) do
+    %{
+      realtime: departure.realtime?,
+      time: format_time(departure.time),
+      delay: departure.delay,
+      scheduled_time: format_time(departure.scheduled_time),
+      trip: render_one(departure.trip, TripView, "trip.json"),
+      route: render_one(departure.route, RouteView, "route.json")
+    }
+  end
+
+  defp format_time(naive_datetime) do
+    naive_datetime
+    |> Timex.to_datetime(:utc)
+    |> Timex.format("{ISO:Extended}")
+    |> case do
+      {:ok, date} -> date
+      error -> error
+    end
+  end
+end

--- a/apps/bus_detective_web/lib/bus_detective_web/views/trip_view.ex
+++ b/apps/bus_detective_web/lib/bus_detective_web/views/trip_view.ex
@@ -1,0 +1,13 @@
+defmodule BusDetectiveWeb.TripView do
+  use BusDetectiveWeb, :view
+
+  def render("trip.json", %{trip: trip}) do
+    %{
+      id: trip.id,
+      headsign: trip.headsign,
+      shape_id: trip.shape_id,
+      block_id: trip.block_id,
+      remote_id: trip.remote_id
+    }
+  end
+end

--- a/apps/bus_detective_web/test/bus_detective_web/controllers/departure_controller_test.exs
+++ b/apps/bus_detective_web/test/bus_detective_web/controllers/departure_controller_test.exs
@@ -1,0 +1,53 @@
+defmodule BusDetectiveWeb.DepartureControllerTest do
+  use BusDetectiveWeb.ConnCase
+
+  alias Timex.Timezone
+
+  setup %{conn: conn} do
+    agency = insert(:agency)
+
+    trip =
+      insert(
+        :trip,
+        agency: agency,
+        remote_id: "940135",
+        service: insert(:service, agency: agency, tuesday: true, wednesday: true)
+      )
+
+    stop = insert(:stop, agency: agency, remote_id: "HAMBELi")
+
+    {
+      :ok,
+      conn: put_req_header(conn, "accept", "application/json"), agency: agency, trip: trip, stop: stop
+    }
+  end
+
+  describe "index" do
+    test "lists all departures for a given stop and time duration in hours", %{
+      conn: conn,
+      agency: agency,
+      stop: stop,
+      trip: trip
+    } do
+      timezone = Timezone.get(agency.timezone)
+
+      {:ok, departure_time} =
+        Timex.now()
+        |> Timezone.convert(timezone)
+        |> Timex.format("%H:%M:%S", :strftime)
+
+      insert(
+        :stop_time,
+        agency: agency,
+        stop: stop,
+        trip: trip,
+        arrival_time: departure_time,
+        departure_time: departure_time
+      )
+
+      conn = get(conn, departure_path(conn, :index, stop_id: stop.id, duration: 1))
+      assert response = json_response(conn, 200)["data"]
+      assert 1 == length(response["departures"])
+    end
+  end
+end

--- a/apps/importer/lib/importer.ex
+++ b/apps/importer/lib/importer.ex
@@ -6,7 +6,7 @@ defmodule Importer do
   require Logger
 
   alias BusDetective.GTFS
-  alias BusDetective.GTFS.{Agency, Route, Service, Shape, Stop, Trip}
+  alias BusDetective.GTFS.{Agency, Interval, Route, Service, Shape, Stop, Trip}
   alias Ecto.Type
 
   def import(gtfs_file) do
@@ -302,20 +302,8 @@ defmodule Importer do
       stop_id = stops_map[{agency_id, raw_stop_time["stop_id"]}]
       trip_id = trips_map[{agency_id, raw_stop_time["trip_id"]}]
 
-      [arr_hours, arr_minutes, arr_seconds] =
-        raw_stop_time["arrival_time"]
-        |> String.split(":")
-        |> Enum.map(&String.to_integer/1)
-
-      arrival_time = arr_hours * 60 * 60 + arr_minutes * 60 + arr_seconds
-
-      [dep_hours, dep_minutes, dep_seconds] =
-        raw_stop_time["departure_time"]
-        |> String.split(":")
-        |> Enum.map(&String.to_integer/1)
-
-      departure_time = dep_hours * 60 * 60 + dep_minutes * 60 + dep_seconds
-
+      {:ok, arrival_time} = maybe_cast(Interval, raw_stop_time["arrival_time"])
+      {:ok, departure_time} = maybe_cast(Interval, raw_stop_time["departure_time"])
       {:ok, shape_dist_traveled} = maybe_cast(:float, raw_stop_time["shape_dist_traveled"])
       {:ok, stop_sequence} = maybe_cast(:integer, raw_stop_time["stop_sequence"])
 

--- a/apps/importer/test/importer/importer_test.exs
+++ b/apps/importer/test/importer/importer_test.exs
@@ -2,7 +2,7 @@ defmodule Importer.ImporterTest do
   use BusDetective.DataCase
 
   alias BusDetective.GTFS
-  alias BusDetective.GTFS.{Agency, Route, Service, ServiceException, Shape, Stop, StopTime, Trip}
+  alias BusDetective.GTFS.{Agency, Interval, Route, Service, ServiceException, Shape, Stop, StopTime, Trip}
 
   setup do
     gtfs_file = Path.join(File.cwd!(), "test/fixtures/google_transit_info.zip")
@@ -197,8 +197,8 @@ defmodule Importer.ImporterTest do
 
     assert %StopTime{
              shape_dist_traveled: 0.3616,
-             arrival_time: 79857,
-             departure_time: 79857
+             arrival_time: %Interval{hours: 22, minutes: 10, seconds: 57},
+             departure_time: %Interval{hours: 22, minutes: 10, seconds: 57}
            } = stop_time
   end
 end


### PR DESCRIPTION
This PR adds the calculated scheduled departures api so that Bus Detective frontend can show scheduled data in the app (not realtime yet). It is API compatible with the Rails app