### PR TITLE
Implement expanding map feature

### DIFF
--- a/apps/bus_detective_web/assets/css/components/map.scss
+++ b/apps/bus_detective_web/assets/css/components/map.scss
@@ -19,7 +19,7 @@
 .map__toggle-expanded {
   position: absolute;
   display: block;
-  top: 100px;
+  top: 10px;
   right: 10px;
   color: $bd-gray;
   z-index: 500;

--- a/apps/bus_detective_web/assets/js/app.js
+++ b/apps/bus_detective_web/assets/js/app.js
@@ -2,12 +2,14 @@
 import '../css/app.scss';
 
 import Departure from './departure.js';
+import ExpandMap from './expand-map.js';
 import NearbySearch from './nearby-search.js';
 import StopMap from './stop-map.js';
 import Route from './route.js';
 import Timestamp from './timestamp.js';
 
 customElements.define('bd-departure', Departure);
+customElements.define('bd-expand-map', ExpandMap);
 customElements.define('bd-nearby-search', NearbySearch);
 customElements.define('bd-stop-map', StopMap);
 customElements.define('bd-timestamp', Timestamp);

--- a/apps/bus_detective_web/assets/js/expand-map.js
+++ b/apps/bus_detective_web/assets/js/expand-map.js
@@ -1,0 +1,26 @@
+/* global HTMLElement */
+class ExpandMap extends HTMLElement {
+
+  connectedCallback () {
+    this.innerHTML = `
+      <button class="map__toggle-expanded button qa-toggle-expanded" id="toggleButton">
+        <i class="bd-icon bd-icon--expand"></i>
+      </button>
+    `;
+
+    let toggleButton = this.querySelector('#toggleButton');
+    let toggleButtonIcon = toggleButton.querySelector('.bd-icon');
+
+    toggleButton.addEventListener('click', function(event) {
+      if(toggleButtonIcon.classList.contains('bd-icon--expand')) {
+        toggleButtonIcon.classList.remove('bd-icon--expand');
+        toggleButtonIcon.classList.add('bd-icon--contract');
+      } else {
+        toggleButtonIcon.classList.remove('bd-icon--contract');
+        toggleButtonIcon.classList.add('bd-icon--expand');
+      }
+    });
+  }
+}
+
+export default ExpandMap;

--- a/apps/bus_detective_web/assets/js/expand-map.js
+++ b/apps/bus_detective_web/assets/js/expand-map.js
@@ -1,6 +1,5 @@
 /* global HTMLElement */
 class ExpandMap extends HTMLElement {
-
   connectedCallback () {
     this.innerHTML = `
       <button class="map__toggle-expanded button qa-toggle-expanded" id="toggleButton">
@@ -11,8 +10,8 @@ class ExpandMap extends HTMLElement {
     let toggleButton = this.querySelector('#toggleButton');
     let toggleButtonIcon = toggleButton.querySelector('.bd-icon');
 
-    toggleButton.addEventListener('click', function(event) {
-      if(toggleButtonIcon.classList.contains('bd-icon--expand')) {
+    toggleButton.addEventListener('click', function (event) {
+      if (toggleButtonIcon.classList.contains('bd-icon--expand')) {
         toggleButtonIcon.classList.remove('bd-icon--expand');
         toggleButtonIcon.classList.add('bd-icon--contract');
       } else {

--- a/apps/bus_detective_web/assets/js/stop-map.js
+++ b/apps/bus_detective_web/assets/js/stop-map.js
@@ -32,7 +32,7 @@ class StopMap extends HTMLElement {
 
     let toggleButton = document.querySelector('#toggleButton');
 
-    toggleButton.addEventListener('click', function(event) {
+    toggleButton.addEventListener('click', function (event) {
       document.querySelector('#stopMap').classList.toggle('map--expanded');
       map.invalidateSize();
     });

--- a/apps/bus_detective_web/assets/js/stop-map.js
+++ b/apps/bus_detective_web/assets/js/stop-map.js
@@ -29,6 +29,13 @@ class StopMap extends HTMLElement {
     map.addLayer(Leaflet.tileLayer(TILE_URL, {detectRetina: true}));
     Leaflet.layerGroup().addTo(map);
     Leaflet.marker(center).addTo(map);
+
+    let toggleButton = document.querySelector('#toggleButton');
+
+    toggleButton.addEventListener('click', function(event) {
+      document.querySelector('#stopMap').classList.toggle('map--expanded');
+      map.invalidateSize();
+    });
   }
 }
 

--- a/apps/bus_detective_web/lib/bus_detective_web/templates/stop/show.html.eex
+++ b/apps/bus_detective_web/lib/bus_detective_web/templates/stop/show.html.eex
@@ -7,6 +7,7 @@
     <a class="button button--return" href="javascript:history.back()">
       <i class="bd-icon bd-icon--arrow-left "></i>
     </a>
+    <bd-expand-map></bd-expand-map>
   </div>
 
   <div class="detail-header">


### PR DESCRIPTION
This was me trying to add back in the expanding map feature. All the styles were already written for it, but I did some js to make it happen. I'm not sure if what I did was the best way. I made a new js component called `expand-map.js` that handles the toggling of the expand/contract button that controls expanding. I also added some js to the existing `stop-map.js` component to actually toggle the map expanding. Maybe this only requires one component instead of two. My reasoning for making the new component was that the button returned in the `expand-map.js` component needed to be in a different place in markup hierarchy than where the `stop-map.js` was outputting its elements.