### PR TITLE
UI Enhancements 

### DIFF
--- a/apps/bus_detective_web/assets/css/components/action-banner.scss
+++ b/apps/bus_detective_web/assets/css/components/action-banner.scss
@@ -15,6 +15,7 @@
 
   .stop-item__toggle-favorite {
     @extend .button, .button--fav;
+    top: $padding;
 
     .material-icons {
       color: #fff;

--- a/apps/bus_detective_web/assets/css/components/action-banner.scss
+++ b/apps/bus_detective_web/assets/css/components/action-banner.scss
@@ -30,7 +30,7 @@
   width: 100%;
   z-index: 10;
   display: flex;
-  padding: 0;
+  padding: $padding;
 
   .button--home {
     background-size: 55%;
@@ -41,14 +41,18 @@
 
   .button--return {
     flex-basis: 40px;
-    margin: 10px;
+  }
+
+  .search__submit {
+    right: $padding / 2;
   }
 
   .search {
-    flex-basis: calc(100% - 100px);
-    margin: 10px;
+    margin-left: $padding;
 
     .search__query {
+      padding-right: $padding * 3;
+      border: 1px solid $bd-light-gray;
       box-shadow: none;
     }
   }

--- a/apps/bus_detective_web/assets/css/components/button.scss
+++ b/apps/bus_detective_web/assets/css/components/button.scss
@@ -2,6 +2,7 @@
   display: inline-block;
   height: 40px;
   width: 40px;
+  min-width: 40px;
   padding: 0;
   color: $bd-gray;
   font-size: 1rem;
@@ -19,7 +20,6 @@
 .button--return {
   color: #fff;
   background-color: transparentize($bd-blue, 0.15);
-  margin-left: 10px;
 }
 
 .button--fav {

--- a/apps/bus_detective_web/assets/css/components/button.scss
+++ b/apps/bus_detective_web/assets/css/components/button.scss
@@ -26,8 +26,8 @@
   color: #fff;
   background-color: transparentize($bd-red, 0.15);
   position: absolute;
-  top: 10px;
-  right: 60px;
+  top: $padding;
+  right: $padding * 4;
   z-index: 500;
   margin-right: 0;
 }

--- a/apps/bus_detective_web/assets/css/components/detail-header.scss
+++ b/apps/bus_detective_web/assets/css/components/detail-header.scss
@@ -22,6 +22,12 @@
   }
 }
 
+.detail-header__details {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(3.5em, 1fr));
+  grid-gap: $padding / 2;
+}
+
 .deatil-header__distance, .deatil-header__location, {
   line-height: 20px;
   color: $bd-gray;

--- a/apps/bus_detective_web/assets/css/components/detail-header.scss
+++ b/apps/bus_detective_web/assets/css/components/detail-header.scss
@@ -1,8 +1,11 @@
 .detail-header {
   @include clearfix;
-  position: relative;
-  padding: $padding;
+  position: sticky;
+  top: 0;
+  padding: $padding $padding ($padding * 1.5);
+  background-color: #ffffff;
   box-shadow: 0 0px 2px 2px transparentize($bd-dark-gray, 0.85);
+  z-index: 1;
 }
 
 .detail-header__title {

--- a/apps/bus_detective_web/assets/css/components/event.scss
+++ b/apps/bus_detective_web/assets/css/components/event.scss
@@ -54,32 +54,17 @@
   width: 20px;
   height: 20px;
   padding: 2px;
-  background-color: #fff;
-  border: 4px solid $bd-gray;
-  border-radius: 50%;
   box-shadow: 0 0 0 0.5rem #fff;
 
   .tag {
     position: absolute;
     top: 50%;
     left: 50%;
+    min-width: 3.5em;
     transform: translate(-50%, -50%);
   }
 }
 
 .event__title {
   margin-top: 0;
-}
-
-// http://stackoverflow.com/a/13287975
-.event--future:first-child,
-:not(.event--future) + .event--future {
-  .event__time {
-    color: $bd-dark-gray;
-  }
-  .event__marker {
-    border: 3px solid $bd-dark-gray;
-    background-color: $bd-dark-gray;
-    box-shadow: 0 0 0 4px #fff, 0 0 0 3px #fff inset;
-  }
 }

--- a/apps/bus_detective_web/assets/css/components/event.scss
+++ b/apps/bus_detective_web/assets/css/components/event.scss
@@ -7,8 +7,16 @@
   float: left;
   width: 23.6%;
   padding-right: ($padding * 2);
-  font-size: $ms0;
-  text-align: right;
+}
+
+.event__schedule_time {
+  margin-top: 0;
+  text-align: center;
+}
+
+.event__relative-time {
+  font-size: $ms-1;
+  text-align: center;
   color: $bd-gray;
 }
 
@@ -16,9 +24,10 @@
   float: left;
   position: relative;
   width: 76.4%;
+  height: ($padding * 7);
   padding-left: ($padding * 2);
-  padding-bottom: ($padding * 3.33);
-  border-left: 3px solid $bd-light-gray;
+  // padding-bottom: ($padding * 3.33);
+  border-left: 2px solid $bd-light-gray;
   & > p {
     font-size: $ms0;
     line-height: 20px;
@@ -44,25 +53,29 @@
   background-color: #fff;
   border: 4px solid $bd-gray;
   border-radius: 50%;
-  box-shadow: 0 0 0 4px #fff;
+  box-shadow: 0 0 0 0.5rem #fff;
+
+  .tag {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
 }
 
 .event__title {
-  margin: $padding 0;
-}
-
-.event__relative-time {
-  color: $bd-gray;
+  margin-top: 0;
 }
 
 // http://stackoverflow.com/a/13287975
-.event--future:first-child, :not(.event--future) + .event--future {
+.event--future:first-child,
+:not(.event--future) + .event--future {
   .event__time {
     color: $bd-dark-gray;
   }
   .event__marker {
     border: 3px solid $bd-dark-gray;
     background-color: $bd-dark-gray;
-    box-shadow: 0 0 0 4px #fff, 0 0 0 4px #fff inset;
+    box-shadow: 0 0 0 4px #fff, 0 0 0 3px #fff inset;
   }
 }

--- a/apps/bus_detective_web/assets/css/components/event.scss
+++ b/apps/bus_detective_web/assets/css/components/event.scss
@@ -1,4 +1,5 @@
 .event--past {
+  display: block;
   opacity: 0.5;
 }
 

--- a/apps/bus_detective_web/assets/css/components/event.scss
+++ b/apps/bus_detective_web/assets/css/components/event.scss
@@ -1,3 +1,8 @@
+.event {
+  display: block;
+  height: ($padding * 7);
+}
+
 .event--past {
   display: block;
   opacity: 0.5;
@@ -24,9 +29,8 @@
   float: left;
   position: relative;
   width: 76.4%;
-  height: ($padding * 7);
+  height: 100%;
   padding-left: ($padding * 2);
-  // padding-bottom: ($padding * 3.33);
   border-left: 2px solid $bd-light-gray;
   & > p {
     font-size: $ms0;

--- a/apps/bus_detective_web/assets/css/components/list.scss
+++ b/apps/bus_detective_web/assets/css/components/list.scss
@@ -45,28 +45,13 @@
   font-size: $ms0;
   font-weight: 600;
   line-height: $ms3;
-
-  small {
-    font-size: $ms-1;
-    font-weight: 400;
-    margin-left : $padding / 2;
-  }
-
-  .tag {
-    position: relative;
-    top: -4px;
-    width: 15.85%;
-    height: 20px;
-    font-size: 14px;
-    line-height: 20px;
-  }
 }
 
 .list-item__subtitle {
-  margin: ($padding / 4) 0 $padding;
+  margin: 0 0 ($padding / 2);
   font-size: $ms-1;
   font-weight: 400;
-  line-height: $ms2;
+  line-height: $ms4;
   color: $bd-gray;
   text-transform: capitalize;
 }

--- a/apps/bus_detective_web/assets/css/components/list.scss
+++ b/apps/bus_detective_web/assets/css/components/list.scss
@@ -32,33 +32,27 @@
 
 .list-item__button {
   float: right;
+  margin: 0;
   color: $bd-light-gray;
+  font-size: $ms1;
   line-height: 2.15;
 }
 
-.list-item__title, .list-item__button {
-  font-size: $ms1;
-  line-height: 2;
-  margin: 0;
-}
-
 .list-item__title {
-  line-height: 1.25;
-  padding-right: $padding;
   width: calc(100% - 2.1em);
-}
-
-.list-item__title--route {
+  margin: 0;
+  padding-right: $padding;
   font-size: $ms0;
-}
+  font-weight: 600;
+  line-height: $ms3;
 
-.list-item__title small {
-  font-size: $ms-1;
-  font-weight: 400;
-  margin-left : $padding / 2;
-}
+  small {
+    font-size: $ms-1;
+    font-weight: 400;
+    margin-left : $padding / 2;
+  }
 
-.list-item__title .tag {
+  .tag {
     position: relative;
     top: -4px;
     width: 15.85%;
@@ -66,21 +60,36 @@
     font-size: 14px;
     line-height: 20px;
   }
+}
+
+.list-item__subtitle {
+  margin: ($padding / 4) 0 $padding;
+  font-size: $ms-1;
+  font-weight: 400;
+  line-height: $ms2;
+  color: $bd-gray;
+  text-transform: capitalize;
+}
+
+.list-item__title--route {
+  font-size: $ms0;
+}
 
 .list-item__details {
   @include clearfix;
   margin-top: $padding / 2;
+
+  .tag {
+    min-width: 15.82%;
+    width: auto;
+    height: $ms0;
+    font-size: $ms-3;
+    line-height: $ms0;
+  }
 }
 
-.list-item__details .tag {
-  min-width: 15.82%;
-  width: auto;
-  height: $ms0;
-  font-size: $ms-3;
-  line-height: $ms0;
-}
-
-.list-item__distance, .list-item__location {
+.list-item__distance,
+.list-item__location {
   margin-top: $padding / 5;
   line-height: $ms0;
   color: $bd-gray;

--- a/apps/bus_detective_web/assets/css/components/list.scss
+++ b/apps/bus_detective_web/assets/css/components/list.scss
@@ -76,15 +76,15 @@
 }
 
 .list-item__details {
-  @include clearfix;
   margin-top: $padding / 2;
 
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(3em, 1fr));
+  grid-gap: $padding / 2;
+
   .tag {
-    min-width: 15.82%;
-    width: auto;
-    height: $ms0;
     font-size: $ms-3;
-    line-height: $ms0;
+    line-height: $ms1;
   }
 }
 

--- a/apps/bus_detective_web/assets/css/components/map.scss
+++ b/apps/bus_detective_web/assets/css/components/map.scss
@@ -19,8 +19,8 @@
 .map__toggle-expanded {
   position: absolute;
   display: block;
-  top: 10px;
-  right: 10px;
+  top: $padding;
+  right: $padding;
   color: $bd-gray;
   z-index: 500;
 }
@@ -34,4 +34,8 @@
 
 .leaflet-marker-icon, .leaflet-tooltip {
   transition: transform 0.6s $ease;
+}
+
+.leaflet-control-zoom.leaflet-bar.leaflet-control {
+  margin: ($padding * 3) ($padding / 2) 0 0;
 }

--- a/apps/bus_detective_web/assets/css/components/stop-item.scss
+++ b/apps/bus_detective_web/assets/css/components/stop-item.scss
@@ -27,14 +27,6 @@
   float: right;
   color: $bd-light-gray;
   background-color: #fff;
-  // same height as the stop-item title
-  line-height: 38px;
-  // make the hit area square
-  width: 38px;
-  // align line item favorite icon with search icon in the control bar at the top of the screen
-  margin-right: -$padding;
-  text-align: center;
-  border-radius: $border-radius;
 
   .list--home & {
     @media screen and (max-width: 520px) {

--- a/apps/bus_detective_web/assets/css/components/stop-item.scss
+++ b/apps/bus_detective_web/assets/css/components/stop-item.scss
@@ -25,6 +25,7 @@
 
 .stop-item__toggle-favorite {
   float: right;
+  margin-right: $padding / -2;
   color: $bd-light-gray;
   background-color: #fff;
 

--- a/apps/bus_detective_web/assets/css/components/tag.scss
+++ b/apps/bus_detective_web/assets/css/components/tag.scss
@@ -2,6 +2,7 @@
   float: left;
   display: inline-block;
   width: 15.82%;
+  min-width: 3.5em;
   height: 20px;
   margin-right: 1%;
   margin-bottom: 2px;

--- a/apps/bus_detective_web/assets/css/components/tag.scss
+++ b/apps/bus_detective_web/assets/css/components/tag.scss
@@ -1,23 +1,14 @@
 .tag {
-  float: left;
-  display: inline-block;
-  width: 15.82%;
-  min-width: 3.5em;
-  height: 20px;
-  margin-right: 1%;
-  margin-bottom: 2px;
+  display: block;
   border-radius: $border-radius;
   color: #FFFFFF;
   background-color: $bd-light-gray;
   text-align: center;
   font-size: $ms-2;
   font-weight: 500;
-  line-height: 20px;
+  line-height: $ms1;
   padding: 0 2px;
   white-space: nowrap;
-  &:nth-of-type(6n) {
-    margin-right: 0;
-  }
 }
 
 .tag--blue {

--- a/apps/bus_detective_web/assets/css/components/timeline.scss
+++ b/apps/bus_detective_web/assets/css/components/timeline.scss
@@ -1,5 +1,5 @@
 .timeline {
-  padding: ($padding * 2.5) $padding;
+  padding: ($padding * 2.5) $padding 0;
 }
 
 .timeline__event {

--- a/apps/bus_detective_web/assets/css/variables.scss
+++ b/apps/bus_detective_web/assets/css/variables.scss
@@ -43,7 +43,7 @@ $ms-3: 0.618rem;  // 9.888px
 // --- DISPLAY --- \\
 // --------------- \\
 
-$padding: 1em;
+$padding: 1rem;
 $border-radius: 2px;
 $box-shadow: 0px 1px 3px transparentize($bd-dark-gray, 0.85);
 

--- a/apps/bus_detective_web/assets/css/variables.scss
+++ b/apps/bus_detective_web/assets/css/variables.scss
@@ -45,7 +45,7 @@ $ms-3: 0.618rem;  // 9.888px
 
 $padding: 1em;
 $border-radius: 2px;
-$box-shadow: 0px 1px 2px transparentize($bd-dark-gray, 0.75);
+$box-shadow: 0px 1px 3px transparentize($bd-dark-gray, 0.85);
 
 
 // ------------------- \\

--- a/apps/bus_detective_web/assets/css/variables.scss
+++ b/apps/bus_detective_web/assets/css/variables.scss
@@ -10,7 +10,7 @@ $bd-red: #ED7161;
 $bd-dark-gray: #4D4D4D;
 $bd-gray: #9F9F9F;
 $bd-light-gray: #DFDFDF;
-$bd-lighter-gray: #EDF0F2;
+$bd-lighter-gray: #EFF3F5;
 
 $primary-color: #0094BA;
 $secondary-color: #FF7B00;

--- a/apps/bus_detective_web/assets/js/departure.js
+++ b/apps/bus_detective_web/assets/js/departure.js
@@ -17,6 +17,8 @@ class Departure extends HTMLElement {
   }
 
   connectedCallback () {
+    this.classList.add('event');
+
     const update = () => {
       if (this.isPast()) {
         this.classList.add('event--past');

--- a/apps/bus_detective_web/assets/js/departure.js
+++ b/apps/bus_detective_web/assets/js/departure.js
@@ -13,7 +13,7 @@ class Departure extends HTMLElement {
   }
 
   get displayedTime () {
-    return moment(this.departure.time).format('hh:mm');
+    return moment(this.departure.time).format('h:mm');
   }
 
   connectedCallback () {
@@ -30,15 +30,14 @@ class Departure extends HTMLElement {
     update();
     this.innerHTML = `
     <div class="${this.departure.removed ? 'removed' : ''} ${this.departure.added ? 'added' : ''}">
-      <div class="event__time">${this.displayedTime}</div>
+      <div class="event__time">
+        <p class="event__schedule_time">${this.displayedTime}</p>
+        <p class="event__relative-time"><bd-timestamp timestamp="${this.departure.time}"></bd-timestamp></p>
+      </div>
       <div class="event__event-details">
-        <div class="event__marker"></div>
+        <div class="event__marker">
+        <bd-route bg-color="${this.departure.route_color}" color="${this.departure.route_text_color}" name="${this.departure.route_name}"></bd-route></div>
         <div>
-          <bd-route bg-color="${this.departure.route_color}" color="${this.departure.route_text_color}" name="${this.departure.route_name}"></bd-route>
-          <span class="event__relative-time">
-            ${this.departure.realtime ? '' : 'scheduled'}
-            <bd-timestamp timestamp="${this.departure.time}"></bd-timestamp>
-          </span>
           <p class="event__title">${this.departure.headsign}</p>
         </div>
       </div>

--- a/apps/bus_detective_web/assets/js/favorite-stop.js
+++ b/apps/bus_detective_web/assets/js/favorite-stop.js
@@ -13,7 +13,8 @@ class FavoriteStop extends HTMLElement {
         <div class="flex__cell flex__cell--large">
           <a href="/stops/${this.favoriteStop.id}" class="unstyled">
             <bd-favorite stop-id="${this.favoriteStop.id}"></bd-favorite>
-            <h1 class="list-item__title">${this.favoriteStop.name}<small class="light">${this.favoriteStop.direction}</small></h1>
+            <h1 class="list-item__title">${this.favoriteStop.name}</h1>
+            <p class="list-item__subtitle">${this.favoriteStop.direction}</p>
             <div class="list-item__details">
               ${this.favoriteStop.routes.map((route) => `
                 <bd-route bg-color="${route.color}" color="${route.text_color}" name="${route.short_name}"></bd-route>

--- a/apps/bus_detective_web/assets/js/route.js
+++ b/apps/bus_detective_web/assets/js/route.js
@@ -1,8 +1,5 @@
 /* global HTMLElement */
 class Route extends HTMLElement {
-  get color () {
-    return this.getAttribute('color');
-  }
 
   get bgcolor () {
     return this.getAttribute('bg-color');
@@ -14,7 +11,7 @@ class Route extends HTMLElement {
 
   connectedCallback () {
     this.innerHTML = `
-    <span class="tag" style="background-color: #${this.bgcolor}; color: #${this.color};">
+    <span class="tag" style="background-color: #${this.bgcolor};">
       ${this.name}
     </span>
     `;

--- a/apps/bus_detective_web/assets/js/timestamp.js
+++ b/apps/bus_detective_web/assets/js/timestamp.js
@@ -18,7 +18,11 @@ class Timestamp extends HTMLElement {
     const relativeTime = timestamp.diff(now);
     const relativeTimeDuration = moment.duration(relativeTime);
 
-    return relativeTimeDuration.minutes() + "m";
+    if (relativeTimeDuration.minutes() < 0) {
+      return null;
+    } else {
+      return relativeTimeDuration.minutes() + "m";
+    }
   }
 
   connectedCallback () {

--- a/apps/bus_detective_web/assets/js/timestamp.js
+++ b/apps/bus_detective_web/assets/js/timestamp.js
@@ -15,10 +15,10 @@ class Timestamp extends HTMLElement {
   get displayedTimestamp () {
     const now = moment();
     const timestamp = moment(this.timestamp);
-    const timestampOffset = timestamp.diff(now);
-    const timestampOffsetDuration = moment.duration(timestampOffset);
+    const relativeTime = timestamp.diff(now);
+    const relativeTimeDuration = moment.duration(relativeTime);
 
-    return timestampOffsetDuration.minutes() + "m";
+    return relativeTimeDuration.minutes() + "m";
   }
 
   connectedCallback () {

--- a/apps/bus_detective_web/assets/js/timestamp.js
+++ b/apps/bus_detective_web/assets/js/timestamp.js
@@ -13,7 +13,12 @@ class Timestamp extends HTMLElement {
   }
 
   get displayedTimestamp () {
-    return moment(this.timestamp).fromNow();
+    const now = moment();
+    const timestamp = moment(this.timestamp);
+    const timestampOffset = timestamp.diff(now);
+    const timestampOffsetDuration = moment.duration(timestampOffset);
+
+    return timestampOffsetDuration.minutes() + "m";
   }
 
   connectedCallback () {

--- a/apps/bus_detective_web/lib/bus_detective_web/templates/departure/_departure.html.eex
+++ b/apps/bus_detective_web/lib/bus_detective_web/templates/departure/_departure.html.eex
@@ -4,13 +4,14 @@
     <div class="event__marker"></div>
     <div>
       <bd-route bg-color="<%= @departure.route.color %>" color="<%= @departure.route.text_color %>" name="<%= @departure.route.short_name %>"></bd-route>
-      <span class="event__relative-time">
+
+      <p class="event__title"><%= @departure.trip.headsign %></p>
+      <p class="event__relative-time">
         <%= unless @departure.realtime? do %>
           scheduled
         <% end %>
         <bd-timestamp timestamp="<%= Timex.format!(@departure.time, "{ISO:Extended}") %>"></bd-timestamp>
-      </span>
-      <p class="event__title"><%= @departure.trip.headsign %></p>
+      </p>
     </div>
   </div>
 </bd-departure>

--- a/apps/bus_detective_web/lib/bus_detective_web/templates/favorite/index.html.eex
+++ b/apps/bus_detective_web/lib/bus_detective_web/templates/favorite/index.html.eex
@@ -1,6 +1,5 @@
 <div>
   <div class="action-banner action-banner--fixed-top">
-    <%= link "", to: home_page_path(@conn, :index), class: "button button--home" %>
     <%= link to: home_page_path(@conn, :index), class: "button button--return" do %>
       <i class="material-icons">arrow_back</i>
     <% end %>

--- a/apps/bus_detective_web/lib/bus_detective_web/templates/search/index.html.eex
+++ b/apps/bus_detective_web/lib/bus_detective_web/templates/search/index.html.eex
@@ -1,7 +1,6 @@
 
 <div>
   <div class="action-banner action-banner--fixed-top">
-    <%= link "", to: home_page_path(@conn, :index), class: "button button--home" %>
     <%= link to: home_page_path(@conn, :index), class: "button button--return" do %>
       <i class="material-icons">arrow_back</i>
     <% end %>

--- a/apps/bus_detective_web/lib/bus_detective_web/templates/stop/_stop.html.eex
+++ b/apps/bus_detective_web/lib/bus_detective_web/templates/stop/_stop.html.eex
@@ -3,7 +3,8 @@
     <div class="flex__cell flex__cell--large">
       <a href="<%= stop_path(BusDetectiveWeb.Endpoint, :show, @stop) %>" class="unstyled">
         <bd-favorite stop-id="<%= Phoenix.Param.to_param(@stop) %>"></bd-favorite>
-        <h1 class="list-item__title"><%= @stop.name %><small class="light"><%= BusDetective.GTFS.Stop.direction(@stop) %></small></h1>
+        <h3 class="list-item__title"><%= @stop.name %></h1>
+        <p class="list-item__subtitle"><%= BusDetective.GTFS.Stop.direction(@stop) %></p>
         <div class="list-item__details">
           <%= for route <- @stop.routes do %>
             <bd-route bg-color="<%= route.color %>" color="<%= route.text_color %>" name="<%= route.short_name %>"></bd-route>

--- a/apps/bus_detective_web/lib/bus_detective_web/templates/stop/show.html.eex
+++ b/apps/bus_detective_web/lib/bus_detective_web/templates/stop/show.html.eex
@@ -8,7 +8,6 @@
   </div>
 
   <div class="action-banner">
-    <%= link "", to: home_page_path(@conn, :index), class: "button button--home" %>
     <a class="button button--return" href="javascript:history.back()">
       <i class="material-icons">arrow_back</i>
     </a>

--- a/apps/bus_detective_web/lib/bus_detective_web/templates/stop/show.html.eex
+++ b/apps/bus_detective_web/lib/bus_detective_web/templates/stop/show.html.eex
@@ -20,7 +20,7 @@
     <h1 class="detail-header__title qa-stop-name"><%= @stop.name %></h1>
     <div class="detail-header__details">
       <%= for route <- @stop.routes do %>
-        <bd-route bg-color="<%= route.color %>" color="<%= route.text_color %>" name="<%= route.short_name %>"></bd-route>
+        <bd-route bg-color="<%= route.color %>" name="<%= route.short_name %>"></bd-route>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
**Description:**
Make layout and style adjustment to UI elements

**Key Changes:**
- Fix departure styles so that they fade out after they leave the stop.
- Add more whitespace to the stop cards in the search results list to improve legibility. 
- Stick the stop detail header to the top of the viewport when scrolling past the map.
- Adjust the layout of the timeline components to improve scanability. 
- Remove the "Home" buttons to improve the layout and usability of the search bar. 

**Screenshots:**
Search results page:
<img width="339" alt="Screen Shot 2019-08-18 at 11 56 41 PM" src="https://user-images.githubusercontent.com/1641169/63238329-ef82ba80-c213-11e9-8e95-86faf1d69408.png">

Stop details page:
<img width="329" alt="Screen Shot 2019-08-18 at 11 57 12 PM" src="https://user-images.githubusercontent.com/1641169/63238339-fdd0d680-c213-11e9-8db0-cdb780f66f8f.png">
